### PR TITLE
Add more TargetFrameworks and optimize dependencies

### DIFF
--- a/jsreport.Client.Test/jsreport.Client.Test.csproj
+++ b/jsreport.Client.Test/jsreport.Client.Test.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />    
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />    
   </ItemGroup>  
 
   <Choose>
@@ -24,8 +24,8 @@
     <Otherwise>
       <ItemGroup>
         <ProjectReference Include="..\jsreport.Client\jsreport.Client.csproj" />
-        <PackageReference Include="jsreport.Local" Version="2.3.2" />
-        <PackageReference Include="jsreport.Binary" Version="3.8.0" />        
+        <PackageReference Include="jsreport.Local" Version="3.8.2" />
+        <PackageReference Include="jsreport.Binary" Version="4.4.0" />        
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/jsreport.Client/jsreport.Client.csproj
+++ b/jsreport.Client/jsreport.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;net6.0</TargetFrameworks>
     <PackageId>jsreport.Client</PackageId>
     <Title>jsreport Client</Title>
     <Authors>Jan Blaha</Authors>
@@ -8,16 +8,16 @@
     <PackageProjectUrl>http://jsreport.net</PackageProjectUrl>
     <PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
     <PackageIconUrl>http://jsreport.net/img/favicon.ico</PackageIconUrl>
-    <Copyright>Copyright 2013-2022 Jan Blaha</Copyright>
+    <Copyright>Copyright 2013-2024 Jan Blaha</Copyright>
     <PackageTags>jsreport;report;pdf</PackageTags>
     <RepositoryUrl>https://github.com/jsreport/net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>3.8.1</Version>
-    <AssemblyVersion>3.8.1</AssemblyVersion>
+    <Version>3.8.2</Version>
+    <AssemblyVersion>3.8.2.0</AssemblyVersion>
     <Company>jsreport</Company>
     <PackageReleaseNotes>Release notes are at https://github.com/jsreport/jsreport-dotnet-client/releases</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <FileVersion>3.8.1.0</FileVersion>
+    <FileVersion>3.8.2.0</FileVersion>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
@@ -31,9 +31,8 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
@@ -46,8 +45,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="jsreport.Types" Version="3.8.1" />        
-        <PackageReference Include="jsreport.Shared" Version="3.8.0" />
+        <PackageReference Include="jsreport.Shared" Version="3.8.3" />
       </ItemGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
Same things as PR https://github.com/jsreport/jsreport-dotnet-types/pull/9.
Also remove Newtonsoft.Json dependencies as it is a transitive dependencie through jsreport.Types project.
Also remove jsreport.Types dependencies as it is a transitive dependencie through jsreport.Shared project.